### PR TITLE
Add deployment manifest template names to bosh template spec object

### DIFF
--- a/instance/templatescompiler/concrete_templates_compiler.go
+++ b/instance/templatescompiler/concrete_templates_compiler.go
@@ -183,6 +183,7 @@ func (tc ConcreteTemplatesCompiler) compileJob(job bpdep.Job, instance bpdep.Ins
 		if err != nil {
 			return "", "", bosherr.WrapError(err, "Preparing runtime dep packages")
 		}
+		relJob.DeploymentJobTemplates = job.Templates
 
 		relJobs = append(relJobs, relJob)
 	}

--- a/instance/templatescompiler/erbrenderer/template_evaluation_context.go
+++ b/instance/templatescompiler/erbrenderer/template_evaluation_context.go
@@ -30,6 +30,11 @@ type rootContext struct {
 }
 
 type jobContext struct {
+	Name      string            `json:"name"`
+	Templates []templateContext `json:"templates"`
+}
+
+type templateContext struct {
 	Name string `json:"name"`
 }
 
@@ -58,7 +63,7 @@ func (c TemplateEvaluationContext) MarshalJSON() ([]byte, error) {
 
 	context := rootContext{
 		Index:      c.instance.Index,
-		JobContext: jobContext{Name: c.instance.JobName},
+		JobContext: jobContext{Name: c.instance.JobName, Templates: c.buildTemplates()},
 		Deployment: c.instance.DeploymentName,
 
 		NetworkContexts: c.buildNetworkContexts(),
@@ -66,6 +71,14 @@ func (c TemplateEvaluationContext) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(context)
+}
+
+func (c TemplateEvaluationContext) buildTemplates() []templateContext {
+	var templates []templateContext
+	for _, template := range c.relJob.DeploymentJobTemplates {
+		templates = append(templates, templateContext{Name: template.Name})
+	}
+	return templates
 }
 
 func (c TemplateEvaluationContext) buildNetworkContexts() map[string]networkContext {

--- a/release/job/job.go
+++ b/release/job/job.go
@@ -1,6 +1,7 @@
 package job
 
 import (
+	bpdep "github.com/cppforlife/bosh-provisioner/deployment"
 	bpreljobman "github.com/cppforlife/bosh-provisioner/release/job/manifest"
 )
 
@@ -13,6 +14,8 @@ type Job struct {
 	MonitTemplate Template
 
 	Templates []Template
+
+	DeploymentJobTemplates []bpdep.Template
 
 	// Runtime package dependencies for this job
 	Packages []Package


### PR DESCRIPTION
We're working on using packer-bosh to create Lattice base images. I had to make some changes to bosh-provisioner to get this template in diego-release to compile:
https://github.com/cloudfoundry-incubator/diego-release/blob/develop/jobs/rep/monit

I'd like to test this, but I don't see any units tests for the code surrounding the changes I made. Let me know if there's an appropriate place to test these changes.